### PR TITLE
fix: revert src paths

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,12 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <link rel="icon" href="/favicon.svg" />
-    <script src="/env-config.js" type="module"></script>
-    <script src="/secret-config.js" type="module"></script>
+    <link rel="icon" href="./favicon.svg" />
+    <script src="./env-config.js" type="module"></script>
+    <script src="./secret-config.js" type="module"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.css" rel="stylesheet" />
     <link href="https://viglino.github.io/font-gis/css/font-gis.css" rel="stylesheet" />
-    <link rel="manifest" href="/manifest.json" />
+    <link rel="manifest" href="./manifest.json" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Telicent Paralog</title>
   </head>


### PR DESCRIPTION
Setting the paths to no be relative makes the build pass locally but not on ci. Whereas doing it this way the opposite is true.