### PR TITLE
fix: ensure config files aren't bundled at build time

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <link rel="icon" href="./favicon.svg" />
-    <script src="./env-config.js" type="module"></script>
-    <script src="./secret-config.js" type="module"></script>
+    <script src="./env-config.js"></script>
+    <script src="./secret-config.js"></script>
     <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v2.2.0/mapbox-gl.css" rel="stylesheet" />
     <link href="https://viglino.github.io/font-gis/css/font-gis.css" rel="stylesheet" />
     <link rel="manifest" href="./manifest.json" />


### PR DESCRIPTION
By adding type module as suggested by vite, it tries to bundle the config when the app gets built. This of course makes it fail because those files aren't available at that point in the pipeline